### PR TITLE
Full Implicit Differentation (ineq only)

### DIFF
--- a/src/IDOC_ineq.py
+++ b/src/IDOC_ineq.py
@@ -50,7 +50,7 @@ def build_blocks_idoc(auxsys_COC, delta=None):
     dynFx_t = auxsys_COC['dynFx_t']
     dynFu_t = auxsys_COC['dynFu_t']
     
-    A_t = [np.block([[GbarHx_t[t], GbarHu_t[t]], [dynFx_t[t], dynFu_t[t]]])  for t in range(T)]
+    A_t = [np.block([[GbarHx_t[t], GbarHu_t[t]], [-dynFx_t[t], -dynFu_t[t]]])  for t in range(T)]
     A_T = GbarHx_T
 
     # B blocks
@@ -62,7 +62,7 @@ def build_blocks_idoc(auxsys_COC, delta=None):
     # C blocks
     GbarHe_t = auxsys_COC['GbarHe_t']
     dynFe_t = auxsys_COC['dynFe_t']
-    C_t = [np.concatenate((GbarHe_t[t], dynFe_t[t]), axis=0) for t in range(T)]
+    C_t = [np.concatenate((GbarHe_t[t], -dynFe_t[t]), axis=0) for t in range(T)]
     C_T = auxsys_COC['GbarHe_T'][0]
 
     return H_t, H_T, A_t, A_T, B_t, B_T, C_t, C_T, ns, nc, T
@@ -71,119 +71,151 @@ def build_blocks_idoc(auxsys_COC, delta=None):
 def idoc_full(H_t, H_T, A_t, A_T, B_t, B_T, C_t, C_T, ns, nc, T):
     nz = B_T.shape[1]
     
-    Hinv_t = np.linalg.inv(H_t)
-    Hinv_T = np.linalg.inv(H_T)
+    inv = np.linalg.inv
+    
+    Hinv_t = inv(H_t)
+    Hinv_T = inv(H_T)
+    
+    # ================== (H^-1 A^T) ======================    
+    assert len(Hinv_t) == len(A_t) == T
+    
+    # Right block
+    HinvAT_upper_t_blocks = [Hinv_t[i] @ A_t[i].T for i in range(T)]
+    HinvAT_upper_T_block = Hinv_T @ A_T.T 
+    
+    # Left block
+    HinvAT_lower_t_blocks = Hinv_t[..., :ns] 
+    # No need to restrict to ns blocks, since the terminal trajectory does not depend on the control
+    HinvAT_lower_T_block = Hinv_T 
 
-    A_t_sz = np.array([A_.shape[0] for A_ in A_t])  # first block treated separately for AH^-1AT
-    A_sz_uniq = set(A_t_sz)
+    # =====================================================
+    
+    # ================== (A H^-1 B - C) ======================    
 
-    # compute and cache (H^1-A^T) expression in Prop. 4.6 in DDN paper
-    HinvAT_upper_t_blocks = T * [None]
-    HinvAT_upper_T_block = Hinv_T @ A_T.T
-    HinvAT_lower_t_blocks = -Hinv_t[..., :ns]
-    HinvAT_lower_t_blocks[0, ...] *= -1.
-    HinvAT_lower_T_block = -Hinv_T
-    for sz in A_sz_uniq:
-        inds = np.where(A_t_sz == sz)[0]
-        A_vec = np.stack([A_t[ind] for ind in inds], axis=0)
-        itemsetter(inds)(HinvAT_upper_t_blocks, Hinv_t[inds] @ A_vec.transpose(0, 2, 1))
-
-    # compute AH^-1B - C in Prop. 4.5 in DDN paper
+    # T + 2 blocks. 1 for the initial state constraint + T for the stage constraints + 1 for the terminal constraint 
     AHinvB_C = (T + 2) * [None]
-    AHinvB_C[0] = Hinv_t[0][:, :ns].T @ B_t[0]
-    AHinvB_C[-1] = HinvAT_upper_T_block.T @ B_T - C_T
-    for sz in A_sz_uniq:
-        inds = np.where(A_t_sz == sz)[0]
-        HinvAT_vec = np.stack([HinvAT_upper_t_blocks[ind] for ind in inds], axis=0)
-        C_vec = np.stack([C_t[ind] for ind in inds], axis=0)
-        lhs_vec = HinvAT_vec.transpose(0, 2, 1) @ B_t[inds, ...] - C_vec
-        if T-1 not in inds:
-            lhs_vec[:, -ns:, :] -= Hinv_t[inds+1, :, :ns].transpose(0, 2, 1) @ B_t[inds+1, ...]
-        else:
-            lhs_vec[:-1, -ns:, :] -= Hinv_t[inds[:-1]+1, :, :ns].transpose(0, 2, 1) @ B_t[inds[:-1]+1, ...]
-            lhs_vec[-1, -ns:, :] -= Hinv_T[:, :ns].T @ B_T
-        itemsetter(inds+1)(AHinvB_C, lhs_vec)           
+    
+    # First block. Dimension state x theta
+    AHinvB_C[0] = HinvAT_lower_t_blocks[0].T @ B_t[0]
+    
+    for i in range(T):
+        # (HinvA.T).T = A Hinv.T = A Hinv [hessian is symmetric]   
+        AHinv = HinvAT_upper_t_blocks[i].T
+        B = B_t[i]
+        C = C_t[i]
+        B_next = B_t[i+1] if i < T - 1 else B_T
+        HT_inv_next = HinvAT_lower_t_blocks[i+1].T if i < T - 1 else HinvAT_lower_T_block.T
+        AHinvB_e = np.matmul(AHinv, B)
+        
+        AHinvB_e[-ns:] += np.matmul(HT_inv_next, B_next)
+        AHinvB_C[i+1] = AHinvB_e - C
+        
+    AHinvB_C[T+1] = np.matmul(HinvAT_upper_T_block.T, B_T) - C_T
+    
+    # =====================================================
+    
+    # ================== (A H^-1 AT) ======================    
+    
+    # AHinvAT is symmetric, it's convenient to store only one side band 
+    AHinvAT_diag = (T + 2) * [None]
+    AHinvAT_lower = (T + 1) * [None]
+    
+    # HinvAT cropped by the identity
+    AHinvAT_diag[0] = HinvAT_lower_t_blocks[0][:ns]
+    
+    for i in range(T):
+        AHinv_up = HinvAT_upper_t_blocks[i].T
+        HinvAT_low = HinvAT_lower_t_blocks[i+1] if i < T - 1 else HinvAT_lower_T_block
+        
+        AT = A_t[i].T
+        AHinvAT_lower[i] = AHinv_up[:, :ns]
+         
+        diag = np.matmul(AHinv_up, AT)
+        diag[-ns:, -ns:] += HinvAT_low[:ns]
+        AHinvAT_diag[i+1] = diag
+        
+    AHinvAT_lower[T] = HinvAT_upper_T_block.T
+    AHinvAT_diag[T+1] = np.matmul(HinvAT_upper_T_block.T, A_T.T)
+    
+    # =====================================================
+    
+    
+    # =============== (AH^-1A^T)^-1(AH^-1B - C) using Thomas's algorithm ===============
+    
+    # solve Ax = B where A is tridiagonal
+    # AH^-1A^T      := A
+    # AH^-1B - C    := B
+    
+    AHinvAT_upper = [AHinvAT_lower[0].T.copy()]
+    for t in range(1, T+1):
+        sz = AHinvAT_diag[t].shape[0]
+        padding = np.zeros((AHinvAT_lower[t].shape[0], sz - ns))
+        AHinvAT_lower[t] = np.concatenate((padding, AHinvAT_lower[t]), axis=1)
+        AHinvAT_upper.append(AHinvAT_lower[t].T.copy())
 
-    # compute AH^-1AT expression in Prop. 4.6 in DDN paper
-    diag_blk = (T + 2) * [None]
-    upper_blk = (T + 1) * [None]
-    # set diag end blocks
-    diag_blk[0] = Hinv_t[0, :ns, :ns].copy()
-    diag_blk[-1] = A_T @ HinvAT_upper_T_block
-    # set upper -1
-    upper_blk[-1] = -HinvAT_upper_T_block[:ns, :].copy()
-    for sz in A_sz_uniq:
-        inds = np.where(A_t_sz == sz)[0]
-        A_vec = np.stack([A_t[ind] for ind in inds], axis=0)
-        HinvAT_vec = np.stack([HinvAT_upper_t_blocks[ind] for ind in inds], axis=0)
-        # diagonal blocks
-        diag_blocks = A_vec @ HinvAT_vec
-        if T-1 not in inds:
-            diag_blocks[:, -ns:, -ns:] += Hinv_t[inds+1, :ns, :ns]
-        else:
-            diag_blocks[:-1, -ns:, -ns:] += Hinv_t[inds[:-1]+1, :ns, :ns]
-            diag_blocks[-1, -ns:, -ns:] += Hinv_T
-        itemsetter(inds+1)(diag_blk, diag_blocks)
-        # upper blocks
-        upper = -HinvAT_vec[:, :ns, :].copy()
-        if 0 in inds:
-            upper[0, ...] *= -1.
-        itemsetter(inds)(upper_blk, upper)
-
-    lower_blk = [upper_blk[0].T.copy()]
-    for t in range(1, T):
-        sz = A_t_sz[t-1]
-        upper_blk[t] = np.concatenate((np.zeros((sz-ns, upper_blk[t].shape[1])), upper_blk[t]), axis=0)
-        lower_blk.append(upper_blk[t].T.copy())
-    upper_blk[T] = np.concatenate((np.zeros((A_t_sz[-1]-ns, upper_blk[T].shape[1])), upper_blk[T]), axis=0)
-    lower_blk.append(upper_blk[T].T.copy())
-
-    # use Thomas's algorithm for block tridiagonal matrices to solve for (AH^-1A^T)^-1(AH^-1B - C)
+    scratch = [None] * (T+1)
     AHinvAT_AHinvB_C = [None] * (T+2)
-    for t in range(1, T+2):
-        CR = np.linalg.solve(diag_blk[t-1], np.concatenate((upper_blk[t-1], AHinvB_C[t-1]), axis=1))
-        n_lhs = upper_blk[t-1].shape[1]
-        upper_blk[t-1], AHinvB_C[t-1] = CR[:, :n_lhs], CR[:, n_lhs:]
+    scratch[0] = np.linalg.solve(AHinvAT_diag[0], AHinvAT_upper[0])
+    AHinvAT_AHinvB_C[0] = np.linalg.solve(AHinvAT_diag[0], AHinvB_C[0])
+    
+    for i in range(1, T+2):
+        lhs = AHinvAT_diag[i] - np.matmul(AHinvAT_lower[i-1], scratch[i-1])
+        if i < T + 1:
+            scratch[i] = np.linalg.solve(lhs, AHinvAT_upper[i])
 
-        diag_blk[t] -= lower_blk[t-1] @ upper_blk[t-1]
-        AHinvB_C[t] -= lower_blk[t-1] @ AHinvB_C[t-1]
+        rhs = AHinvB_C[i] - np.matmul(AHinvAT_lower[i-1], AHinvAT_AHinvB_C[i-1])
+        AHinvAT_AHinvB_C[i] = np.linalg.solve(lhs, rhs)
+        
+    for i in range(T, -1, -1):
+        AHinvAT_AHinvB_C[i] -= np.matmul(scratch[i], AHinvAT_AHinvB_C[i+1])
+    # =====================================================
+    
+    # ================== (H^-1 B) ======================    
 
-    AHinvAT_AHinvB_C[-1] = np.linalg.solve(diag_blk[T+1], AHinvB_C[-1])
-    AHinvAT_AHinvB_C[T] = AHinvB_C[T] - upper_blk[T] @ AHinvAT_AHinvB_C[-1]
-    for t in reversed(range(T)):  # backward recursion
-        AHinvAT_AHinvB_C[t] = AHinvB_C[t] - upper_blk[t] @ AHinvAT_AHinvB_C[t+1]
+    HinvB_t = [np.matmul(Hinv_t[i], B_t[i]) for i in range(T)]
+    HinvB_T = np.matmul(Hinv_T, B_T)
+    
+    HinvB = np.vstack(HinvB_t+[HinvB_T])
+    
+    # =====================================================
+    
+    # =============== H^-1 A^T (AH^-1A^T)^-1(AH^-1B - C) ===============
 
-    # multiply by H^-1AT to get H^-1AT(AH^-1A^T)^-1(AH^-1B - C) (left term, projection to constraint surface)
-    rhs_bottom_vec = np.stack([blk[-ns:, :] for blk in AHinvAT_AHinvB_C[:-2]], axis=0)
-    left_term = HinvAT_lower_t_blocks @ rhs_bottom_vec
-    left_term_T = HinvAT_lower_T_block @ AHinvAT_AHinvB_C[-2] + HinvAT_upper_T_block @ AHinvAT_AHinvB_C[-1]
-    left_term = np.concatenate((left_term.reshape(-1, nz), left_term_T), axis=0)
+    AHinvAT_AHinvB_C_v = np.vstack(AHinvAT_AHinvB_C)
 
-    left_term1 = T * [None]
-    for sz in A_sz_uniq:
-        inds = np.where(A_t_sz == sz)[0]
-        rhs_vec = np.stack([AHinvAT_AHinvB_C[ind+1] for ind in inds], axis=0)
-        HinvAT_block_vec = np.stack([HinvAT_upper_t_blocks[ind] for ind in inds], axis=0)
-        left_block = HinvAT_block_vec @ rhs_vec
-        itemsetter(inds)(left_term1, left_block)
-    left_term[:-ns, :] += np.concatenate(left_term1, axis=0)
+    left_side = [None] * (T+1)
 
-    # solve right term (gradient of unconstrained problem) H^-1B and subtract from left term
-    left_term[:-ns, :] -= (Hinv_t @ B_t).reshape(-1, nz)
-    left_term[-ns:, :] -= Hinv_T @ B_T 
+    slide_idx = 0
+    for i in range(T + 1):
+        l = HinvAT_lower_t_blocks[i] if i < T else HinvAT_lower_T_block
+        r = HinvAT_upper_t_blocks[i] if i < T else HinvAT_upper_T_block
+        n_cstr = r.shape[1]
+        
+        x1 = AHinvAT_AHinvB_C_v[slide_idx : slide_idx+ns]
+        x2 = AHinvAT_AHinvB_C_v[slide_idx+ns : slide_idx+ns+n_cstr]
+        
+        left_side[i] =  np.matmul(l, x1)
+        left_side[i] += np.matmul(r, x2)
+        
+        slide_idx += n_cstr
 
-    # unpack full
-    dxu_dp_t = left_term[:-ns, :].reshape(T, ns+nc, nz)
-    dx_dp = np.concatenate((dxu_dp_t[:, :ns, :], left_term[None, -ns:, :]), axis=0)
+    left_side = np.vstack(left_side)
+    
+    # =====================================================
+    
+    # =============== full expression ===============
+    
+    idoc = left_side - HinvB
+    
+    dxu_dp_t = idoc[:-ns, :].reshape(T, ns+nc, nz)
+    dx_dp = np.concatenate((dxu_dp_t[:, :ns, :], idoc[None, -ns:, :]), axis=0)
     du_dp = dxu_dp_t[:, ns:, :]
-
     time_ = [k for k in range(T + 1)]
     sol_full = {'state_traj_opt': dx_dp,
                 'control_traj_opt': du_dp,
                 'time': time_}
-
+    
     return sol_full
-
 
 def idoc_vjp(demo_traj, traj, H_t, H_T, A_t, A_T, B_t, B_T, C_t, C_T, ns, nc, T):
     nz = B_T.shape[1]


### PR DESCRIPTION
This PR contains a reimplementation of IDOC.  The previous version had a nasty bug when the number of constraints at time `T-1` didn't match the number of states at time `T`.  As before, the implementation evaluates the IDOC expression in `O(n)` by leveraging sparse computation. 

The new implementation has been tested against the previous one on all the SafePDP [JinEnv](https://github.com/wanxinjin/Safe-PDP/tree/main/JinEnv) environments. By fixing the random seed, the new implementation converges to the same parameters as the former, meaning that the two implementations are functionally equivalent for those cases.

The execution time changes, which is better for some problems and worse for others. The tests were conducted on an Intel Core i9-14900HX. The times reported in the table were computed by averaging 100 iterations. 

| Problem   | Old (s)  | New (s)  | % Change |
|------------|-----------|-----------|------------------------|
| Cartpole   | 0.00177   | 0.00137   | **−22.6%** |
| Quadrotor  | 0.00169   | 0.00143   | **−15.4%** |
| Robotarm   | 0.00125   | 0.00123   | **−1.6%**  |
| Rocket     | 0.00228   | 0.00262   | **+14.9%** |

The sensitivity computation was also tested on the glider perching problem, which revealed the previous issue. Now it converges properly.

This PR contains only the inequality full IDOC. It would be useful to apply the same changes to the jacobian vector product and the equality IDOC as well. That will be future work.


For Thomas's algorithm, I implemented [Wikipedia's version](https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm).

The plots below show the matrix's sparse structure for the intermediate steps. 

<img width="498" height="435" alt="image" src="https://github.com/user-attachments/assets/ad31fdc1-725f-4aff-a034-a181c08d9355" />

<img width="323" height="435" alt="image" src="https://github.com/user-attachments/assets/1a5558b4-3564-4312-8b51-c6b372b2c90e" />

<img width="323" height="435" alt="image" src="https://github.com/user-attachments/assets/2a4ef21b-fef2-4774-9c4b-df8b3adb7a13" />

<img width="498" height="435" alt="image" src="https://github.com/user-attachments/assets/accbe715-d82a-44bc-8b44-0869fc0665cb" />

<img width="270" height="435" alt="image" src="https://github.com/user-attachments/assets/51527076-7f23-4030-a4d9-d027d1b995bc" />

<img width="338" height="435" alt="image" src="https://github.com/user-attachments/assets/9630ccb4-b5a4-433f-8808-61bbbaa5c2f6" />
 